### PR TITLE
Fill documentation gaps and re-aggregate component docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**The-OASIS-Project.github.io** is the public documentation website for the O.A.S.I.S. wearable computing platform. It's built with MkDocs and the Material theme, hosted on GitHub Pages at [oasisproject.net](https://www.oasisproject.net/).
+**The-OASIS-Project.github.io** is the public documentation website for the O.A.S.I.S. wearable computing platform. Built with MkDocs and the Material theme, it aggregates documentation from all component repositories via S.C.O.P.E. (the meta-repo) and publishes the unified site to [oasisproject.net](https://www.oasisproject.net/). Component repos own their documentation; this repo aggregates and publishes it.
 
 ---
 
@@ -13,17 +13,24 @@ github-pages/
 ├── docs/                    # Documentation source (Markdown)
 │   ├── index.md             # Home page
 │   ├── overview.md          # Project overview
-│   ├── mirage.md            # MIRAGE HUD docs
-│   ├── dawn.md              # DAWN AI docs
-│   ├── aura.md              # AURA sensor docs
-│   ├── spark.md             # SPARK gauntlet docs
-│   ├── beacon.md            # Parts catalog
-│   ├── comms.md             # Communications architecture
-│   ├── llm.md               # Local LLM setup
+│   ├── videos.md            # Video content
+│   ├── components/          # Aggregated component documentation
+│   │   ├── mirage.md        # MIRAGE HUD (from repos/mirage/docs/guide.md)
+│   │   ├── dawn.md          # DAWN AI (from repos/dawn/docs/guide.md)
+│   │   ├── dawn-llm.md      # DAWN LLM setup (from repos/dawn/docs/local-llm.md)
+│   │   ├── aura.md          # AURA helmet (from repos/aura/docs/guide.md)
+│   │   ├── spark.md         # SPARK gauntlet (from repos/spark/docs/guide.md)
+│   │   ├── beacon.md        # BEACON parts (from repos/beacon/docs/parts-catalog.md)
+│   │   └── genesis.md       # GENESIS utilities (from repos/genesis/docs/guide.md)
+│   ├── architecture/        # Aggregated coordination documentation
+│   │   └── mqtt-protocols.md  # (from coordination/protocols/mqtt-communication.md)
 │   ├── assets/              # Images, logos, media
 │   ├── stylesheets/         # Custom CSS (extra.css)
 │   └── blog/                # Blog posts
-├── mkdocs.yml               # Site configuration
+├── scripts/
+│   ├── aggregate_docs.py    # Documentation aggregation script
+│   └── test_aggregate_docs.py  # Aggregation tests (25 pytest tests)
+├── mkdocs.yml               # Site configuration and navigation
 ├── CNAME                    # Custom domain (oasisproject.net)
 └── .github/workflows/       # GitHub Actions for deployment
 ```
@@ -135,19 +142,67 @@ The site deploys automatically via GitHub Actions when changes are pushed to `ma
 
 ---
 
+## Documentation Aggregation
+
+### Content Decomposition (ADR-0004)
+
+Documentation lives in the repository closest to the code it describes. This repo aggregates that content into a unified site. Component repos own their docs; this repo owns the build and presentation.
+
+| Content Type | Source of Truth | Aggregated To |
+|--------------|-----------------|---------------|
+| Component docs | `repos/<component>/docs/guide.md` | `docs/components/<component>.md` |
+| Coordination docs | `coordination/protocols/*.md` | `docs/architecture/*.md` |
+| Site-specific | This repo (`docs/`) | `docs/` (root) |
+
+### Running Aggregation
+
+The aggregation script pulls documentation from sibling submodules when this repo is checked out as part of S.C.O.P.E.:
+
+```bash
+# From this repo's root (within S.C.O.P.E.)
+python scripts/aggregate_docs.py
+
+# Preview what would be copied without modifying files
+python scripts/aggregate_docs.py --dry-run
+
+# Specify S.C.O.P.E. root explicitly
+python scripts/aggregate_docs.py --scope-root /path/to/meta-repo
+```
+
+The script auto-detects the S.C.O.P.E. root by walking up the directory tree. It pulls from whatever branch each submodule is currently checked out to.
+
+### When to Re-Run Aggregation
+
+Re-run `aggregate_docs.py` and commit the results when:
+- Component `docs/guide.md` files have been updated
+- Coordination documentation has changed
+- New components are added to `COMPONENT_DOCS` mapping in the script
+
+### Adding a New Component
+
+1. Add the mapping to `COMPONENT_DOCS` in `scripts/aggregate_docs.py`
+2. Add a nav entry to `mkdocs.yml`
+3. Run `python scripts/aggregate_docs.py`
+4. Commit the aggregated file and config changes
+
+### CI Note
+
+The CI workflow (`ci.yml`) currently deploys from committed content only. It does not run aggregation automatically. Automated CI aggregation is deferred until the project reaches steady-state maintenance (see ADR-0004).
+
 ## Integration Points
 
 ### O.A.S.I.S. Ecosystem
 
 This site documents all O.A.S.I.S. components:
-- Component READMEs should link here for user-facing docs
-- Technical details stay in component repos
-- This site focuses on getting started and tutorials
+- Component repos own their documentation in `docs/guide.md`
+- The aggregation script pulls component docs into this site
+- Site-specific content (videos, credits, blog) lives directly in this repo
 
 ### S.C.O.P.E. Coordination
 
 - **Meta-repo**: [malcolmhoward/the-oasis-project-meta-repo](https://github.com/malcolmhoward/the-oasis-project-meta-repo)
-- Documentation changes may need coordination with component updates
+- This repo is a S.C.O.P.E. submodule at `repos/github-pages`
+- Documentation changes coordinate with component updates via the aggregation script
 
 ---
 

--- a/docs/components/aura.md
+++ b/docs/components/aura.md
@@ -4,9 +4,38 @@
 
 This code is a healthy mix of example code from various libraries with a special thanks to Adafruit for their awesome hardware and software.
 
+## Overview
+
+A.U.R.A. (Advanced Utility for Reliable Acquisition) is the embedded helmet firmware for the O.A.S.I.S. ecosystem. It collects environmental and motion sensor data from the helmet, relays it to MIRAGE for HUD display, and controls the motorized faceplate.
+
+AURA runs on an ESP32-S3 microcontroller (v2.5) using FreeRTOS for concurrent sensor polling, display updates, and communication. It supports two communication modes: ESP-NOW for low-latency peer-to-peer links with SPARK gauntlets, and WiFi/MQTT for integration with the broader O.A.S.I.S. network.
+
+Key capabilities:
+- 9-DOF IMU (BNO086) for head tracking (roll, pitch, heading)
+- GPS positioning via SparkFun u-blox GNSS
+- Environmental monitoring: CO2, temperature, humidity, air quality (TVOC, eCO2)
+- Motorized faceplate control with servo-driven open/close/toggle
+- ESP-NOW encrypted peer-to-peer communication with SPARK devices
+- FreeRTOS multi-task architecture across dual cores
+
 **Note:** I will have a circuit diagram in the future. This is a pretty simple one though. All of the devices are I2C devices that can be daisy-chained and it's powered by USB.
 
 ## Hardware
+
+### v2.5 (Current - ESP32-S3)
+
+| Component | Description | Interface |
+|-----------|-------------|-----------|
+| ESP32-S3 TFT Feather | Main processor with WiFi and ESP-NOW | — |
+| SparkFun BNO086 | 9-DOF IMU (accelerometer, gyroscope, magnetometer) | SPI |
+| SparkFun u-blox GNSS | GPS module (latitude, longitude, altitude, speed) | UART or I2C |
+| ScioSense ENS160 | Air quality sensor (eCO2, TVOC) | I2C (0x53) |
+| Sensirion SCD41 | CO2, temperature, and humidity sensor | I2C (0x62) |
+| ST7789 TFT Display | 240x135 pixel color display for local status | SPI |
+| Servos (x2) | Faceplate open/close motors | GPIO 12, 13 |
+| NeoPixel LEDs | Eye/status indicators | GPIO |
+
+### v1 (Legacy - Teensy 4.0)
 
 * [Teensy 4.0](https://www.pjrc.com/store/teensy40.html) - Main Processor
 * [Adafruit LSM6SDSOX+LIS3MDL](http://adafru.it/4517) - 9-DOF Sensor
@@ -33,3 +62,142 @@ This code is a healthy mix of example code from various libraries with a special
 ## Building
 
 This firmware is currently being built in the Arduino IDE using the libraries and target hardware mentioned above.
+
+For v2.5 (ESP32-S3):
+1. Open `aura-v2.5/aura-v2.5.ino` in Arduino IDE 2.x
+2. Select board: ESP32-S3 Dev Module or Feather
+3. Configure `arduino_secrets.h` with WiFi credentials (if using WiFi mode)
+4. Review `config.h` for hardware pin assignments and sensor settings
+5. Upload via USB
+
+Alternatively, using Arduino CLI:
+```bash
+arduino-cli compile --fqbn esp32:esp32:esp32s3 aura-v2.5/
+arduino-cli upload -p /dev/ttyUSB0 --fqbn esp32:esp32:esp32s3 aura-v2.5/
+```
+
+## Configuration
+
+Configuration is managed through `aura-v2.5/config.h`:
+
+### Communication Mode
+
+Select one communication mode (not both simultaneously):
+- `#define ESPNOW_MODE` — ESP-NOW peer-to-peer (recommended)
+- `#define WIFI_MODE` — WiFi with MQTT/Socket
+
+### Network Settings (WiFi mode)
+
+- MQTT broker port: `1883`
+- Socket port: `3000`
+- WiFi credentials: Set in `arduino_secrets.h`
+
+### ESP-NOW Settings
+
+- Channel: 1 (configurable, must match SPARK devices)
+- Shared PMK key: 16-byte encryption key (must match SPARK)
+- Maximum peers: 20
+
+### Sensor Settings
+
+| Sensor | Key Settings |
+|--------|-------------|
+| BNO086 IMU | SPI pins: INT=6, RST=9, WAKE=10; Update interval: 100ms |
+| GPS (u-blox) | UART pins: TX=39, RX=38; Baud: 38400 (factory) / 115200 (high speed) |
+| Environmental (I2C) | SDA=3, SCL=4; CO2 thresholds: Excellent <600, Good <800, Fair <1000, Poor <1500 ppm |
+
+### Faceplate Servo
+
+- Servo pins: GPIO 12, GPIO 13
+- Angles: Open=0°, Closed=77°, Backoff=1° (anti-jam protection)
+
+## Usage
+
+1. Flash the firmware (see Building section above)
+2. Connect via USB serial at 115200 baud for debug output
+3. AURA automatically initializes sensors and starts FreeRTOS tasks:
+   - `gpsTask` — GPS polling (Core 1)
+   - `imuTask` — IMU updates (Core 0, highest priority)
+   - `enviroTask` — Environmental sensor readings (Core 1)
+   - `displayTask` — TFT display updates (Core 0)
+   - `messagingTask` — Communication dispatch (Core 1)
+   - `servoTask` — Faceplate motor control (Core 0)
+   - `espnowTask` — ESP-NOW communication (Core 1, ESP-NOW mode only)
+
+### Serial Commands
+
+Send JSON commands via USB serial for testing:
+```json
+{"action": "faceplate", "value": "open"}
+{"action": "faceplate", "value": "close"}
+{"action": "faceplate", "value": "toggle"}
+```
+
+## Communication
+
+AURA supports two communication modes, selectable in `config.h`.
+
+### ESP-NOW Mode (Recommended)
+
+Direct peer-to-peer WiFi using encrypted ESP-NOW protocol. SPARK gauntlets register as peers during startup:
+
+1. SPARK sends registration message with its topic identifier
+2. AURA checks for duplicate topics and responds with ACK or REJECT
+3. After ACK, encrypted communication begins
+
+ESP-NOW message types:
+
+| Type | Name | Purpose |
+|------|------|---------|
+| 1 | REGISTRATION | Device registration request |
+| 2 | REG_ACK | Registration acknowledged |
+| 3 | REG_REJECT | Registration rejected (duplicate topic) |
+| 4 | DATA | Sensor data transfer |
+| 5 | DATA_ACK | Data acknowledgment |
+| 6 | PING | Connectivity check |
+| 7 | PONG | Ping response |
+
+Inactive peers are timed out after 30 seconds.
+
+### WiFi/MQTT Mode (Alternative)
+
+When in WiFi mode, AURA connects to an MQTT broker.
+
+| Direction | Topic | Purpose |
+|-----------|-------|---------|
+| Subscribe | `helmet` | Receives commands (faceplate control, LED control) |
+| Publish | Sensor data topics | Sends IMU, GPS, and environmental readings |
+
+Incoming command format: `{"action": "<action>", "value": "<value>"}`.
+
+### Data Published
+
+Regardless of communication mode, AURA provides:
+
+| Data | Source Sensor | Update Rate |
+|------|--------------|-------------|
+| Roll, Pitch, Heading | BNO086 IMU | 100ms |
+| Latitude, Longitude, Altitude, Speed | u-blox GNSS | GPS fix rate |
+| CO2 (ppm), Temperature, Humidity | SCD41 | Sensor polling interval |
+| eCO2 (ppm), TVOC (ppb), Air Quality Index | ENS160 | Sensor polling interval |
+
+## Troubleshooting
+
+| Issue | Possible Cause | Solution |
+|-------|---------------|----------|
+| IMU not detected | SPI wiring or pin mismatch | Verify BNO086 SPI pins (INT=6, RST=9, WAKE=10) in `config.h` |
+| GPS no fix | Antenna not connected or indoors | Move to open sky; check UART pins (TX=39, RX=38) |
+| I2C sensors not found | Wrong bus or address conflict | Check SDA=3, SCL=4; verify ENS160 (0x53) and SCD41 (0x62) addresses |
+| ESP-NOW peers not registering | Channel mismatch or wrong PMK | Ensure channel and PMK key match between AURA and SPARK |
+| WiFi connection fails | Wrong credentials | Check `arduino_secrets.h` SSID and password |
+| Faceplate servo jams | Angle calibration | Adjust OPEN/CLOSED angles in `config.h`; check backoff angle |
+| Display not updating | SPI pin conflict | Verify ST7789 pins (CS=42, DC=40, RST=41) don't conflict with BNO086 |
+| Build fails | Missing board support | Install ESP32 board support in Arduino IDE; verify board selection is ESP32-S3 |
+| Serial garbled output | Wrong baud rate | Set serial monitor to 115200 baud |
+
+## Related Components
+
+- [M.I.R.A.G.E.](https://www.oasisproject.net/components/mirage/) - Receives helmet sensor data (IMU, GPS, environmental) for HUD display
+- [D.A.W.N.](https://www.oasisproject.net/components/dawn/) - Sends faceplate commands to AURA via `helmet` MQTT topic
+- [S.P.A.R.K.](https://www.oasisproject.net/components/spark/) - Registers as ESP-NOW peer; sends hand sensor data to AURA for relay
+- [B.E.A.C.O.N.](https://www.oasisproject.net/components/beacon/) - CAD models for the helmet enclosure that houses AURA hardware

--- a/docs/components/genesis.md
+++ b/docs/components/genesis.md
@@ -1,0 +1,158 @@
+# G.E.N.E.S.I.S. - GEneral Nexus for Experimental Software and Informative Scripts (Python Utilities)
+
+<img src="https://www.oasisproject.net/assets/GENESIS_Logo_bg.png" alt="GENESIS Logo" width="350" align="right">
+
+## Overview
+
+G.E.N.E.S.I.S. (GEneral Nexus for Experimental Software and Informative Scripts) is the Python utilities repository for the O.A.S.I.S. ecosystem. It provides computer vision, camera integration, and hardware interaction scripts for Raspberry Pi and NVIDIA Jetson platforms.
+
+GENESIS contains standalone utilities that support development and experimentation across the ecosystem. Each utility is self-contained with its own dependencies and documentation.
+
+Current utilities:
+- **Pi ChatGPT Vision Trigger** — Camera-based text detection with GPIO control using OpenAI Vision API
+- **Simple PiCamera HUD** — Lightweight heads-up display for Raspberry Pi cameras with real-time overlays
+- **Jetson RTSP Server** — RTSP streaming server for NVIDIA Jetson with CSI, USB, and ZED camera support
+
+## Software Dependencies
+
+### Pi ChatGPT Vision Trigger
+
+- Python 3.7+
+- pygame 2.6.1, openai 1.12.0, RPi.GPIO 0.7.1, requests 2.31.0, pillow 10.2.0, pyyaml 6.0.1, numpy 1.26.4
+- Raspberry Pi with camera module and GPIO
+- OpenAI API key
+
+### Simple PiCamera HUD
+
+- Python 3.7+
+- pygame, picamera2, numpy
+- Raspberry Pi with camera module
+
+### Jetson RTSP Server
+
+- Python 3.7+
+- PyGObject, GStreamer 1.0 and plugins, NVIDIA encoder libraries
+- NVIDIA Jetson platform
+- Optional: ZED SDK (for ZED camera support)
+
+## Installation
+
+Each utility is installed independently within its own directory.
+
+### Pi ChatGPT Vision Trigger
+
+```bash
+cd pi_chatgpt_vision_trigger
+python -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+export OPENAI_API_KEY="your-api-key-here"
+```
+
+### Simple PiCamera HUD
+
+No additional installation required beyond system Python packages (pygame, picamera2, numpy).
+
+### Jetson RTSP Server
+
+```bash
+cd jetson_rtsp_server
+bash setup.sh        # Installs system dependencies and creates venv
+source env/bin/activate
+```
+
+The setup script installs GStreamer development libraries, creates a virtual environment, and installs PyGObject bindings. ZED SDK must be installed separately if ZED camera support is needed.
+
+## Configuration
+
+### Pi ChatGPT Vision Trigger
+
+Edit `pi_chatgpt_vision_trigger/config.yaml`:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `led_pin` | 17 | GPIO pin for output device (BCM numbering) |
+| `screen_width` / `screen_height` | 800 x 600 | Preview window size |
+| `camera_width` / `camera_height` | 1920 x 1080 | Native camera capture resolution |
+| `capture_interval` | 5 | Seconds between captures |
+| `max_image_width` / `max_image_height` | 1920 x 1080 | Maximum dimensions for API submission |
+| `trigger_words` | [example, test, detect, word] | Words that trigger GPIO activation |
+| `min_api_interval` | 1 | Minimum seconds between API calls |
+
+### Simple PiCamera HUD
+
+Configuration is set in the script source:
+
+```python
+camera_resolution = (1920, 1080)
+desired_framerate = 30
+rotate = 0  # 0, 90, 180, or 270 degrees
+```
+
+### Jetson RTSP Server
+
+All settings are passed as command-line arguments (see Usage).
+
+## Usage
+
+### Pi ChatGPT Vision Trigger
+
+```bash
+cd pi_chatgpt_vision_trigger
+source env/bin/activate
+python pi_chatgpt_vision_trigger.py
+```
+
+Exit: Press ESC, close window, or Ctrl+C. Logs are written to `vision_trigger.log`.
+
+### Simple PiCamera HUD
+
+```bash
+python simple_picamera_hud.py
+```
+
+Keyboard controls:
+- `E` or `Q` — Quit
+- `P` — Shutdown system
+- `F` — Toggle fullscreen
+
+### Jetson RTSP Server
+
+```bash
+cd jetson_rtsp_server
+source env/bin/activate
+
+# CSI camera (default)
+python rtsp_server.py --camera csi --width 1920 --height 1080
+
+# USB camera
+python rtsp_server.py --camera usb --device-id 0 --width 1280 --height 720
+
+# ZED camera
+python rtsp_server.py --camera zed --device-id 0 --width 1920 --height 1080
+```
+
+Stream URL: `rtsp://<device-ip>:<port>/camera` (default port 8554).
+
+Command-line options: `--camera`, `--device-id`, `--width`, `--height`, `--framerate`, `--port`, `--bitrate`.
+
+## Troubleshooting
+
+| Issue | Possible Cause | Solution |
+|-------|---------------|----------|
+| Camera not detected (Pi) | libcamera not installed or camera disabled | Run `sudo raspi-config` and enable camera interface |
+| OpenAI API errors | Invalid or missing API key | Verify `OPENAI_API_KEY` environment variable is set |
+| GPIO permission denied | Script not running with GPIO access | Run with `sudo` or add user to `gpio` group |
+| Poor text recognition | Image resolution too low or poor lighting | Increase `camera_width`/`camera_height`; improve lighting |
+| RTSP stream not accessible | Firewall blocking port | Open port 8554 (or configured port) in firewall |
+| GStreamer pipeline error | Missing plugins or encoder | Run `setup.sh` to install dependencies; verify NVIDIA drivers |
+| pygame display error | No display connected or X11 not available | Set `SDL_VIDEODRIVER=dummy` for headless, or connect display |
+| ZED camera not found | ZED SDK not installed | Install ZED SDK separately from stereolabs.com |
+| High API costs | Capture interval too short | Increase `capture_interval` and `min_api_interval` in config |
+
+## Related Components
+
+- [M.I.R.A.G.E.](https://www.oasisproject.net/components/mirage/) - Simple PiCamera HUD shares concepts with the MIRAGE display system
+- [D.A.W.N.](https://www.oasisproject.net/components/dawn/) - Vision trigger can interface with DAWN's AI assistant capabilities
+- [A.U.R.A.](https://www.oasisproject.net/components/aura/) - Jetson RTSP server can stream camera feeds alongside AURA sensor data
+- [B.E.A.C.O.N.](https://www.oasisproject.net/components/beacon/) - CAD models for hardware that runs GENESIS utilities

--- a/docs/components/mirage.md
+++ b/docs/components/mirage.md
@@ -2,6 +2,14 @@
 
 <img src="https://www.oasisproject.net/assets/screenshot_gtc.png" alt="MIRAGE HUD" width="800" />
 
+## Overview
+
+M.I.R.A.G.E. is the primary visual interface for the O.A.S.I.S. ecosystem. It renders a real-time heads-up display (HUD) on dual high-resolution screens mounted inside a helmet, overlaying sensor data, navigation, object detection, and system status onto the wearer's field of view.
+
+MIRAGE receives telemetry from all other O.A.S.I.S. components via MQTT — orientation from the IMU, environmental readings from sensors, GPS positioning, and connectivity status from each armor piece — and composites this data into a fully configurable UI driven by `config.json`. It also sends text-to-speech commands to D.A.W.N. for audio feedback and streams video to remote viewers.
+
+Built in C with SDL2 for rendering, MIRAGE runs on NVIDIA Jetson platforms and supports stereo display output, camera passthrough, recording/streaming, and hotkey-driven UI toggling.
+
 ## Application Notes
 
 * Google API/Maps - A Google API key is required for the current implementation of the maps overlay for access to Google Maps. Getting an API key is currently beyond the scope of this document. Please see Google's documentation for details.
@@ -331,3 +339,81 @@ The "Components" section of the `config.json` is dedicated to monitoring various
 * **`online file`:** The file (usually green) shown once a connection to the component has been successfully made, signaling that the component is active and functioning.
 * **`warning file`:** The file (commonly yellow) displayed when the component enters a warning state, such as overheating or low battery, prompting user attention to potential issues.
 * **`offline file`:** The visual (typically red) used to indicate that the component has lost connection or is otherwise not communicating, alerting the user to a significant problem.
+
+## Communication
+
+MIRAGE communicates with all other O.A.S.I.S. components via MQTT. See the [O.A.S.I.S. Communication Protocols](https://www.oasisproject.net/architecture/mqtt-protocols/) for full message format details.
+
+### Subscribed Topics
+
+| Topic | Purpose | Key Payload Fields |
+|-------|---------|-------------------|
+| `hud` | HUD switching and control | `action`: set/switchHUD, `value`: HUD name, `transitionType` |
+| `helmet` | Faceplate commands (forwarded to serial) | Raw command string |
+| `stat` | System metrics and battery status | `device`: SystemMetrics/Fan/BatteryStatus |
+| *Armor components* | Per-piece connectivity and telemetry | `device`, `temp`, `voltage`, orientation data |
+
+Armor component topics are dynamically subscribed based on `config.json` entries (e.g., `shoulder/left`, `chest`, `repulsor/right`, `thigh/left`).
+
+### Additional Received Messages
+
+MIRAGE also processes these message types on subscribed topics:
+
+| Device Type | Purpose | Key Fields |
+|-------------|---------|------------|
+| `Motion` | IMU orientation for compass/pitch/roll | `heading`, `pitch`, `roll` |
+| `Enviro` | Environmental sensor readings | `temp`, `humidity`, `co2_ppm`, `air_quality` |
+| `GPS` | Position and navigation data | `latitude`, `longitude`, `altitude`, `speed`, `satellites` |
+| `audio` | Audio playback commands | `command`: play/stop, `arg1`: filename |
+| `ai` | AI model state changes | `name`, `state` |
+| `map` | Map zoom/type/refresh control | `action`, `value` |
+| `record`/`stream` | Recording and streaming control | `action`: enable/disable |
+
+### Published Topics
+
+| Topic | Purpose | Payload |
+|-------|---------|---------|
+| `dawn` | Text-to-speech requests | `{"device": "text to speech", "action": "play", "value": "<text>"}` |
+| `dawn` | AI snapshot notifications | Image path and metadata |
+
+MIRAGE publishes to the `dawn` topic for audio feedback — armor connection/disconnection announcements, HUD switch confirmations, recording status alerts, and startup/shutdown messages.
+
+### QoS and Configuration
+
+- All subscriptions use **QoS level 1** (at least once delivery)
+- MQTT broker address configured at build time or via environment
+- Armor component deregistration timeout configurable via `armor_deregister` setting
+
+## Troubleshooting
+
+### Display Issues
+
+* **Black screen on startup**: Verify DisplayPort cable connections to the Wisecoco driver board. Check that the Jetson is outputting to the correct display.
+* **Stereo offset incorrect**: Adjust the `Stereo Offset` value in `config.json`. Negative values shift left, positive shift right.
+* **Low frame rate**: Check `Stream Width`/`Stream Height` — streaming at high resolution impacts performance. Verify GPU utilization with `jtop`.
+
+### Camera Issues
+
+* **Camera not detected**: Run `sudo /opt/nvidia/jetson-io/jetson-io.py` to verify CSI connector configuration. Ensure IMX477 Dual is selected.
+* **CSI cable connection**: The Arducam CSI to HDMI extension modules require firm seating at both ends. Reseat cables if the camera feed is intermittent.
+
+### Build Issues
+
+* **Missing dependencies**: Ensure all packages from the Installation Notes are installed. The `libmosquitto-dev` and `mosquitto` packages are required for MQTT.
+* **CMake errors**: Verify Jetson Inference is built and installed before building MIRAGE.
+
+### MQTT Issues
+
+* **Armor pieces showing offline (red)**: Check that the component is publishing to the correct MQTT topic matching the `device` field in `config.json`. Verify the MQTT broker is running: `systemctl status mosquitto`.
+* **No audio feedback**: Verify D.A.W.N. is running and subscribed to the `dawn` topic. Check MQTT broker connectivity.
+
+### SPI Issues
+
+* **SPI device not found**: Verify SPI is enabled via `jetson-io.py` (Configure Jetson 40pin Header → Enable 'spi1'). A reboot may be required after configuration changes.
+
+## Related Components
+
+- [D.A.W.N.](https://www.oasisproject.net/components/dawn/) - Receives text-to-speech commands from MIRAGE via the `dawn` MQTT topic; provides voice command processing
+- [A.U.R.A.](https://www.oasisproject.net/components/aura/) - Publishes sensor telemetry (environmental, GPS, IMU) and faceplate status that MIRAGE displays on the HUD
+- [S.P.A.R.K.](https://www.oasisproject.net/components/spark/) - Publishes repulsor/peripheral telemetry (voltage, temperature, audio commands) displayed on the armor status panel
+- [B.E.A.C.O.N.](https://www.oasisproject.net/components/beacon/) - Provides the physical mounting hardware (HUD frame, speaker chassis) that houses MIRAGE's displays and cameras

--- a/docs/components/spark.md
+++ b/docs/components/spark.md
@@ -4,14 +4,37 @@
 
 This code is a healthy mix of example code from various libraries with a special thanks to Adafruit for their awesome hardware and software.
 
+## Overview
+
+S.P.A.R.K. (Sensor-based Positioning and Actuation Repulsor Kinetics) is the embedded hand/gauntlet firmware for the O.A.S.I.S. ecosystem. It provides gesture recognition, environmental sensing, and visual feedback for wearable gauntlet devices.
+
+SPARK runs on ESP32-based microcontrollers and supports two communication modes: WiFi/MQTT for network integration and ESP-NOW for low-latency peer-to-peer links with the AURA helmet hub. The firmware includes two variants: a full gauntlet implementation with IMU gesture recognition and NeoPixel effects (`spark-v1`), and a generic sensor node for auxiliary mounting points (`spark-generic-v1`).
+
+Key capabilities:
+- IMU-based gesture recognition (power-up and fire gestures) with configurable thresholds
+- NeoPixel LED effects (19 LEDs: 7 jewel + 12 ring) for visual feedback
+- Environmental sensing (temperature, humidity via AHT20)
+- Battery voltage monitoring
+- Dual communication: WiFi/MQTT or ESP-NOW encrypted peer-to-peer
+- Audio command dispatch for gesture-triggered sound effects
+
 **Note:** I will have a circuit diagram in the future. This is a pretty simple one though. All of the devices are I2C devices that can be daisy-chained and it's powered by USB.
 
 ## Hardware
 
+### spark-v1 (Right Hand Gauntlet)
+
 * [Adafruit QT Py ESP32-S3](https://www.adafruit.com/product/5426)
-* [Adafruit LSM6DSO32](https://www.adafruit.com/product/4692)
+* [Adafruit LSM6DSO32](https://www.adafruit.com/product/4692) - 6-DOF IMU (accelerometer + gyroscope)
 * [NeoPixel Jewel - 7 x 5050 RGB LED](https://www.adafruit.com/product/2226)
 * [NeoPixel Ring - 12 x 5050 RGB LED](https://www.adafruit.com/product/1643)
+
+### spark-generic-v1 (Generic Sensor Node)
+
+| Component | Description | Link |
+|-----------|-------------|------|
+| Seeed XIAO ESP32-C3 | Primary microcontroller (also supports ESP32-S3/S2) | [Seeed Studio](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html) |
+| Adafruit AHT20 | Temperature and humidity sensor (I2C) | [Adafruit](https://www.adafruit.com/product/4566) |
 
 ## Libraries
 
@@ -24,3 +47,120 @@ This code is a healthy mix of example code from various libraries with a special
 ## Building
 
 This firmware is currently being built in the Arduino IDE using the libraries and target hardware mentioned above.
+
+1. Open `spark-v1/spark-v1.ino` or `spark-generic-v1/spark-generic-v1.ino` in Arduino IDE 2.x
+2. Select board: Seeed XIAO ESP32-C3 (generic) or Adafruit QT Py ESP32-S3 (v1)
+3. Configure `arduino_secrets.h` with WiFi credentials and ESP-NOW PMK
+4. Upload via USB
+
+Alternatively, using Arduino CLI:
+```bash
+arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32C3 spark-generic-v1/
+arduino-cli upload -p /dev/ttyUSB0 --fqbn esp32:esp32:XIAO_ESP32C3 spark-generic-v1/
+```
+
+## Configuration
+
+### Communication Mode
+
+Set in the `.ino` file (compile-time):
+- `#define COMMUNICATION_MODE COMM_MODE_WIFI` — WiFi with MQTT
+- `#define COMMUNICATION_MODE COMM_MODE_ESPNOW` — ESP-NOW peer-to-peer
+
+### Network Settings
+
+- WiFi credentials and ESP-NOW PMK: `arduino_secrets.h`
+- MQTT broker: Auto-detected from WiFi gateway IP, port 1883
+- ESP-NOW channel: 1 (configurable via `ESPNOW_CHANNEL`)
+- Connection retry attempts: 5 (configurable via `CONN_RETRY_ATTEMPTS`)
+
+### Pin Assignments
+
+| Pin | ESP32-C3 | ESP32-S3/S2 | Purpose |
+|-----|----------|-------------|---------|
+| Voltage ADC | A0 | A2 | Battery voltage monitoring |
+| LED Data | GPIO 10 | GPIO 35 | NeoPixel data line (spark-v1) |
+
+### Gesture Thresholds (spark-v1)
+
+| Gesture | Axis | Threshold | Description |
+|---------|------|-----------|-------------|
+| Power activation | accel.x | > 7.0 m/s² | Arm raise to power up |
+| Fire activation | accel.x | > 9.2 m/s² | Quick thrust to fire |
+
+IMU settings: Accelerometer range 16G, Gyroscope range 1000 DPS, Data rate 12.5 Hz.
+
+### Data Transmission Intervals
+
+- spark-generic-v1: Every 5 seconds
+- spark-v1: Every 1 second (sensor data), ~64ms (gesture loop)
+
+## Usage
+
+1. Flash the firmware (see Building section)
+2. Monitor via serial at 115200 baud for debug output
+3. The device automatically:
+   - Connects to WiFi/MQTT broker or discovers AURA via ESP-NOW broadcast
+   - Begins sensor polling and data transmission
+   - (spark-v1) Monitors IMU for gestures and drives NeoPixel effects
+
+### MQTT Topics
+
+- spark-v1 publishes to: `repulsor/right`
+- spark-generic-v1 publishes to: `shoulder/left`
+
+## Communication
+
+SPARK supports two communication modes, selectable at compile time.
+
+### WiFi/MQTT Mode
+
+Connects to the MQTT broker (auto-detected from WiFi gateway IP, port 1883).
+
+| Direction | Topic | Payload Example |
+|-----------|-------|-----------------|
+| Publish | `repulsor/right` (v1) or `shoulder/left` (generic) | `{"device": "repulsor/right", "voltage": 4.20, "temp": 24.5}` |
+| Publish | `dawn` | `{"device": "audio", "command": "play", "arg1": "hand_rep_fire2.ogg"}` (gesture events, v1 only) |
+| Subscribe | Device-specific topic | `{"device": "<name>", "value": <integer>}` |
+
+### ESP-NOW Mode
+
+Direct peer-to-peer communication with AURA as the hub. Uses encrypted ESP-NOW with shared PMK.
+
+Registration flow:
+1. SPARK broadcasts registration message with its topic identifier
+2. AURA responds with ACK (accepted) or REJECT (duplicate topic)
+3. After ACK, encrypted data exchange begins
+4. Inactive connections timeout after 30 seconds; rejected peers retry after 35 seconds
+
+ESP-NOW message types: REGISTRATION, REG_ACK, REG_REJECT, DATA, DATA_ACK, PING, PONG.
+
+### Data Transmitted
+
+| Data | Source | Variant |
+|------|--------|---------|
+| Battery voltage | ADC pin | Both |
+| Temperature | AHT20 (generic) or LSM6DSO32 internal (v1) | Both |
+| Humidity | AHT20 | Generic only |
+| Gesture events (audio commands) | LSM6DSO32 IMU | v1 only |
+
+## Troubleshooting
+
+| Issue | Possible Cause | Solution |
+|-------|---------------|----------|
+| WiFi connection fails | Wrong credentials | Check `arduino_secrets.h` SSID and password |
+| ESP-NOW registration rejected | Duplicate topic on hub | Use a unique topic identifier per device |
+| ESP-NOW no hub found | Channel mismatch or AURA offline | Verify ESP-NOW channel matches AURA; ensure AURA is powered |
+| No sensor data | I2C wiring issue | Check I2C connections (SDA/SCL); verify sensor power |
+| Battery voltage reads 0 | Wrong ADC pin for board | Use A0 for ESP32-C3, A2 for ESP32-S3/S2 |
+| NeoPixels not lighting | Wrong LED pin or power | Verify LED_PIN matches board; check 5V power supply |
+| IMU gestures not triggering | Thresholds too high | Adjust acceleration thresholds in gesture detection code |
+| Build fails | Missing board support | Install ESP32 board support package in Arduino IDE |
+| Serial output garbled | Wrong baud rate | Set serial monitor to 115200 |
+
+## Related Components
+
+- [A.U.R.A.](https://www.oasisproject.net/components/aura/) - SPARK registers as an ESP-NOW peer with AURA; sends sensor data for relay to the HUD
+- [D.A.W.N.](https://www.oasisproject.net/components/dawn/) - Receives gesture-triggered audio commands via MQTT (`dawn` topic)
+- [M.I.R.A.G.E.](https://www.oasisproject.net/components/mirage/) - Displays hand/gauntlet sensor feedback on the HUD
+- [B.E.A.C.O.N.](https://www.oasisproject.net/components/beacon/) - CAD models for the gauntlet enclosure that houses SPARK hardware

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,143 @@
+# The O.A.S.I.S. Project Documentation Portal
+
+<img src="https://www.oasisproject.net/assets/logo.png" alt="O.A.S.I.S. Logo" width="350" align="right">
+
+## Overview
+
+The O.A.S.I.S. Project documentation portal is the public-facing website for the O.A.S.I.S. wearable computing platform. Built with MkDocs and the Material theme, it aggregates documentation from all component repositories into a unified, searchable site hosted at [oasisproject.net](https://www.oasisproject.net/).
+
+The portal serves as the primary entry point for users, contributors, and anyone interested in the O.A.S.I.S. ecosystem. It provides component documentation, architecture guides, video content, and a blog.
+
+## Software Dependencies
+
+| Component | Technology | Purpose |
+|-----------|------------|---------|
+| [MkDocs](https://www.mkdocs.org/) | Static site generator | Builds Markdown into HTML |
+| [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) | Theme | Navigation, search, responsive design |
+| [mkdocs-video](https://github.com/soulless-viewer/mkdocs-video) | Plugin | Embedded video support |
+| [mkdocs-glightbox](https://github.com/blueswen/mkdocs-glightbox) | Plugin | Image lightbox overlays |
+| Python 3.7+ | Runtime | Required by MkDocs |
+
+## Installation
+
+### Prerequisites
+
+- Python 3.7+
+- pip
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/The-OASIS-Project/The-OASIS-Project.github.io.git
+cd The-OASIS-Project.github.io
+
+# Install dependencies
+pip install mkdocs-material mkdocs-video mkdocs-glightbox
+```
+
+## Configuration
+
+Site configuration is managed through `mkdocs.yml`:
+
+| Setting | Location | Purpose |
+|---------|----------|---------|
+| `site_name` | `mkdocs.yml` | Site title |
+| `nav` | `mkdocs.yml` | Navigation structure and page ordering |
+| `theme.palette` | `mkdocs.yml` | Color scheme (ironman theme) |
+| `plugins` | `mkdocs.yml` | Enabled plugins (search, social, blog, video, glightbox) |
+| `CNAME` | Root | Custom domain (oasisproject.net) |
+| `extra.css` | `docs/stylesheets/extra.css` | Custom CSS overrides |
+
+### Adding a New Page
+
+1. Create a `.md` file in `docs/`
+2. Add an entry to the `nav:` section in `mkdocs.yml`
+3. Preview locally with `mkdocs serve`
+
+## Usage
+
+### Local Development
+
+```bash
+# Serve with live reload (http://localhost:8000)
+mkdocs serve
+
+# Build static site to site/ directory
+mkdocs build
+```
+
+### Deployment
+
+The site deploys automatically via GitHub Actions when changes are pushed to `main`:
+
+1. GitHub Actions checks out the code
+2. Builds the site with `mkdocs build`
+3. Deploys to the `gh-pages` branch
+4. GitHub Pages serves from that branch at oasisproject.net
+
+### Content Structure
+
+```
+docs/
+├── index.md                    # Home page
+├── overview.md                 # Project overview
+├── videos.md                   # Video content
+├── components/                 # Component documentation
+│   ├── mirage.md               # MIRAGE HUD
+│   ├── dawn.md                 # DAWN AI assistant
+│   ├── dawn-llm.md             # DAWN local LLM setup
+│   ├── aura.md                 # AURA helmet firmware
+│   ├── spark.md                # SPARK gauntlet firmware
+│   └── beacon.md               # BEACON parts catalog
+├── architecture/               # Architecture documentation
+│   └── mqtt-protocols.md       # MQTT communication protocols
+├── assets/                     # Images, logos, media
+├── stylesheets/                # Custom CSS
+├── blog/                       # Blog posts
+├── opensource.md                # Open source acknowledgments
+└── credits.md                  # Project credits
+```
+
+### Documentation Aggregation
+
+When checked out as part of S.C.O.P.E. (the meta-repo), this site can aggregate documentation from all component repositories. Each component maintains its own `docs/guide.md` as the source of truth, and the aggregation pipeline compiles them into the portal.
+
+| Source | Destination |
+|--------|-------------|
+| `repos/<component>/docs/guide.md` | `docs/components/<component>.md` |
+| `repos/<component>/docs/<topic>.md` | `docs/components/<component>-<topic>.md` |
+| `coordination/protocols/*.md` | `docs/architecture/*.md` |
+
+The portal can also be built standalone using only its own content in `docs/`. The aggregation step is optional and only runs when the site is built within the S.C.O.P.E. context.
+
+See [ADR-0004: Documentation Infrastructure](https://github.com/malcolmhoward/the-oasis-project-meta-repo/blob/main/coordination/decisions/adr/0004-documentation-infrastructure.md) for the full aggregation architecture.
+
+### Writing Style
+
+- Write for makers and developers
+- Use clear, concise language
+- Include code examples where helpful
+- Add images/diagrams for complex concepts
+- Use MkDocs Material admonitions (`!!! note`, `!!! warning`) for callouts
+
+## Troubleshooting
+
+| Issue | Possible Cause | Solution |
+|-------|---------------|----------|
+| `mkdocs serve` fails | Missing dependencies | Run `pip install mkdocs-material mkdocs-video mkdocs-glightbox` |
+| Page not appearing in nav | Not added to `mkdocs.yml` | Add entry to `nav:` section in `mkdocs.yml` |
+| Images not loading | Wrong path | Use relative paths from `docs/` (e.g., `assets/image.png`) |
+| Custom CSS not applied | Cache or wrong path | Clear browser cache; verify path in `extra_css` section |
+| Deployment fails | GitHub Actions workflow error | Check `.github/workflows/` for configuration; verify branch permissions |
+| Blog posts not showing | Missing metadata | Ensure blog posts have required front matter (date, title) |
+| Video embeds broken | Missing plugin | Verify `mkdocs-video` is installed and listed in `plugins:` |
+
+## Related Components
+
+- [M.I.R.A.G.E.](https://www.oasisproject.net/components/mirage/) - HUD system documentation aggregated from component repo
+- [D.A.W.N.](https://www.oasisproject.net/components/dawn/) - AI assistant documentation aggregated from component repo
+- [A.U.R.A.](https://www.oasisproject.net/components/aura/) - Helmet firmware documentation aggregated from component repo
+- [S.P.A.R.K.](https://www.oasisproject.net/components/spark/) - Gauntlet firmware documentation aggregated from component repo
+- [B.E.A.C.O.N.](https://www.oasisproject.net/components/beacon/) - Parts catalog aggregated from component repo
+- S.C.O.P.E. - Meta-repo that coordinates this portal as a submodule alongside all component repos

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
     - A.U.R.A.: components/aura.md
     - S.P.A.R.K.: components/spark.md
     - B.E.A.C.O.N. Parts: components/beacon.md
+    - G.E.N.E.S.I.S.: components/genesis.md
   - Architecture:
     - MQTT Protocols: architecture/mqtt-protocols.md
   - Special Thanks: opensource.md

--- a/scripts/aggregate_docs.py
+++ b/scripts/aggregate_docs.py
@@ -41,7 +41,7 @@ COMPONENT_DOCS = {
         ("docs/parts-catalog.md", "components/beacon.md"),
     ],
     "genesis": [
-        # Add genesis docs when available
+        ("docs/guide.md", "components/genesis.md"),
     ],
 }
 


### PR DESCRIPTION
## Summary
- Create docs/guide.md per ecosystem documentation standard
- Re-aggregate component docs to reflect gap-filled content from all component repos
- Add GENESIS mapping to aggregate_docs.py and mkdocs.yml navigation
- Update CLAUDE.md with aggregation workflow documentation and publishing role

Component documentation improvements reflected in this re-aggregation:
- MIRAGE: +86 lines (Overview, Communication, Troubleshooting, Related Components)
- DAWN: +68 lines (Overview, Communication with AI states, Troubleshooting)
- AURA: +168 lines (v2.5 hardware, FreeRTOS tasks, ESP-NOW, Troubleshooting)
- SPARK: +142 lines (dual variants, gesture config, ESP-NOW, Troubleshooting)
- GENESIS: new file (3 utilities documented)

Tracked by: malcolmhoward/the-oasis-project-meta-repo#29

## Test plan
- [ ] Verify guide.md has all required sections per ecosystem documentation standard
- [ ] Verify aggregated docs match component repo sources
- [ ] Verify mkdocs.yml nav includes all components
- [ ] Run python scripts/aggregate_docs.py --dry-run to verify mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)